### PR TITLE
15 prepare data before validation

### DIFF
--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -384,8 +384,9 @@ class _Property(object):
                     ))
             return str_or_func
         else:
-            raise TypeError("prepare argument to property must be a str name of a pre-registered prepare function, a"
-                            "custom one-argument function or a list of any of the previous values")
+            raise TypeError("prepare argument to property must be a str name of a pre-registered prepare function, a" +
+                            "custom one-argument function or a list of any of the previous values, " +
+                            "received: {} of type {}".format(str_or_func, str_or_func.__class__.__name__))
 
 
 # noinspection PyAbstractClass

--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -219,7 +219,7 @@ class _Property(object):
     the setting of prestans attributes on it's containing class
     """
 
-    def __init__(self, of_type, required=True, default=None, **kwargs):
+    def __init__(self, of_type, required=True, default=None, prepare=None, **kwargs):
         """
         :param of_type: The class of the |type| being configured. Must be a subclass of |ImmutableType|
         :type of_type: T <= :attr:`ImmutableType.__class__<prestans3.types.ImmutableType>`

--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -344,17 +344,18 @@ class _Property(object):
 
         def _func(instance):
             """ recursively resolves and calls prepare functions in order """
-            if hasattr(self.prepare, '__iter__') and hasattr(self.prepare, '__len__'):
-                def _all(x, rest):
-                    if len(rest) == 0:
-                        return x
-                    return _all(self._resolve_prepare_function(rest[0])(x), rest[1:])
-
-                return lambda x: _all(x, self.prepare)
+            if not is_str(self.prepare) and hasattr(self.prepare, '__iter__') and hasattr(self.prepare, '__len__'):
+                return self._aggregate_prepare_functions(instance, self.prepare)
             else:
                 return self._resolve_prepare_function(self.prepare)
 
         return _func(self.prepare)
+
+    def _aggregate_prepare_functions(self, x, rest):
+        if len(rest) == 0:
+            return x
+        return self._aggregate_prepare_functions(self._resolve_prepare_function(rest[0])(x), rest[1:])
+
 
     def _resolve_prepare_function(self, str_or_func):
         """

--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -197,6 +197,11 @@ class ImmutableType(with_metaclass(_PrestansTypeMeta, object)):
                 for rule_name, rule in list(cls.property_rules.items()) if rule.default_config}
 
 
+    @classmethod
+    def register_prepare_function(cls, func):
+        pass
+
+
 _property_rule_graph = LazyOneWayGraph(ImmutableType)
 _config_check_graph = LazyOneWayGraph(ImmutableType)
 

--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -348,7 +348,7 @@ class _Property(object):
             if hasattr(self.prepare, '__iter__'):
                 pass
 
-    def _resolve_preapre_function(self, str_or_func):
+    def _resolve_prepare_function(self, str_or_func):
         """
         will resolve a string into the named function stored in self.__class__.prepare_functions dictionary and throw an
         error on no resolution or will return the function provided given it accepts only one argument

--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -241,7 +241,7 @@ class _Property(object):
                                                     of_type.default_rules_config())
         self.required = required
         self.default = default
-        self.prepare = prepare
+        self.prepare = prepare if prepare is not None else []
 
     def __set__(self, instance, value):
         """
@@ -254,10 +254,11 @@ class _Property(object):
         :type value: T <= G
         """
         # if value is a ImmutableType then set it otherwise construct it from variable
+        prepared_value = self.prepare_process_function(value[1])
         if isinstance(value[1], self._of_type):
-            instance[value[0]] = value[1]
+            instance[value[0]] = prepared_value
         else:
-            instance[value[0]] = self._of_type.from_value(value[1])
+            instance[value[0]] = self._of_type.from_value(prepared_value)
 
     # noinspection PyUnusedLocal
     def __get__(self, instance, owner):

--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -26,9 +26,16 @@ class _ConfigChecksProperty(object):
         return _config_check_graph[cls]
 
 
+class _PrepareFunctionsProperty(object):
+    # noinspection PyUnusedLocal
+    def __get__(self, cls, _mcs):
+        return _prepare_functions_graph[cls]
+
+
 class _PrestansTypeMeta(type):
     property_rules = _PropertyRulesProperty()  # type: dict[str, (T <= ImmutableType, any) -> None]
     config_checks = _ConfigChecksProperty()  # type: dict[str, (type, any) -> None]
+    prepare_functions = _PrepareFunctionsProperty()  # type: dict[str, (T <= ImmutableType) -> T]
 
 
 class ImmutableType(with_metaclass(_PrestansTypeMeta, object)):
@@ -196,7 +203,6 @@ class ImmutableType(with_metaclass(_PrestansTypeMeta, object)):
         return {rule_name: rule.default_config if not callable(rule.default_config) else rule.default_config()
                 for rule_name, rule in list(cls.property_rules.items()) if rule.default_config}
 
-
     @classmethod
     def register_prepare_function(cls, func):
         pass
@@ -204,6 +210,7 @@ class ImmutableType(with_metaclass(_PrestansTypeMeta, object)):
 
 _property_rule_graph = LazyOneWayGraph(ImmutableType)
 _config_check_graph = LazyOneWayGraph(ImmutableType)
+_prepare_functions_graph = LazyOneWayGraph(ImmutableType)
 
 
 def _choices(instance, config):

--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -343,10 +343,18 @@ class _Property(object):
         """
 
         def _func(instance):
-            if is_str(self.prepare):
-                pass
-            if hasattr(self.prepare, '__iter__'):
-                pass
+            """ recursively resolves and calls prepare functions in order """
+            if hasattr(self.prepare, '__iter__') and hasattr(self.prepare, '__len__'):
+                def _all(x, rest):
+                    if len(rest) == 0:
+                        return x
+                    return _all(self._resolve_prepare_function(rest[0])(x), rest[1:])
+
+                return lambda x: _all(x, self.prepare)
+            else:
+                return self._resolve_prepare_function(self.prepare)
+
+        return _func(self.prepare)
 
     def _resolve_prepare_function(self, str_or_func):
         """
@@ -375,6 +383,9 @@ class _Property(object):
                         ", ".join(str_or_func.__code__.co_varnames)
                     ))
             return str_or_func
+        else:
+            raise TypeError("prepare argument to property must be a str name of a pre-registered prepare function, a"
+                            "custom one-argument function or a list of any of the previous values")
 
 
 # noinspection PyAbstractClass

--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -342,24 +342,23 @@ class _Property(object):
         :return: a function that will process the string
         """
 
-        def _func(instance):
-            """ recursively resolves and calls prepare functions in order """
-            if not is_str(self.prepare) and hasattr(self.prepare, '__iter__') and hasattr(self.prepare, '__len__'):
-                return self._aggregate_prepare_functions(instance, self.prepare)
-            else:
-                return self._resolve_prepare_function(self.prepare)
+        """ recursively resolves and calls prepare functions in order """
+        if not is_str(self.prepare) and hasattr(self.prepare, '__iter__') and hasattr(self.prepare, '__len__'):
+            return self._aggregate_prepare_functions(self.prepare)
+        else:
+            return self._resolve_prepare_function(self.prepare)
 
-        return _func(self.prepare)
+    def _aggregate_prepare_functions(self, rest):
+        def _all(x, tail):
+            if len(tail) < 1:
+                return x
+            return _all(self._resolve_prepare_function(tail[0])(x), tail[1:])
 
-    def _aggregate_prepare_functions(self, x, rest):
-        if len(rest) == 0:
-            return x
-        return self._aggregate_prepare_functions(self._resolve_prepare_function(rest[0])(x), rest[1:])
-
+        return lambda x: _all(x, rest)
 
     def _resolve_prepare_function(self, str_or_func):
         """
-        will resolve a string into the named function stored in self.__class__.prepare_functions dictionary and throw an
+        Will resolve a string into the named function stored in self.__class__.prepare_functions dictionary and throw an
         error on no resolution or will return the function provided given it accepts only one argument
 
         :param str_or_func: name of a predefined and registered prepare function or a custom function with one argument

--- a/prestans3/types/__init__.py
+++ b/prestans3/types/__init__.py
@@ -362,7 +362,11 @@ class _Property(object):
         :return: (t: T <= ImmutableType) -> T
         """
         if is_str(str_or_func):
-            return self.property_type.prepare_functions[str_or_func]
+            try:
+                return self.property_type.prepare_functions[str_or_func]
+            except KeyError:
+                raise KeyError(
+                    "'{}' is not a registered prepare function of {}".format(str_or_func, self.property_type.__name__))
         if callable(str_or_func):
             if str_or_func.__code__.co_argcount != 1:
                 raise TypeError(

--- a/prestans3/types/string.py
+++ b/prestans3/types/string.py
@@ -56,6 +56,11 @@ def _format_regex(instance, config):
                                                                                                      config))
 
 
+String.register_property_rule(_min_length, name="min_length")
+String.register_property_rule(_max_length, name="max_length")
+String.register_property_rule(_format_regex, name="format_regex")
+
+
 def _min_max_string_check_config(type, config):
     if config is not None and 'min_length' in config and 'max_length' in config \
             and config['min_length'] > config['max_length']:
@@ -64,7 +69,4 @@ def _min_max_string_check_config(type, config):
                                       type.__name__, config['min_length'], config['max_length']))
 
 
-String.register_property_rule(_min_length, name="min_length")
-String.register_property_rule(_max_length, name="max_length")
-String.register_property_rule(_format_regex, name="format_regex")
 String.register_config_check(_min_max_string_check_config, name="min_max_string_check_config")

--- a/prestans3/types/string.py
+++ b/prestans3/types/string.py
@@ -76,4 +76,9 @@ def _prepare_trim(x):
     return x.strip()
 
 
+def _prepare_normalize_whitespace(x):
+    return re.sub(r'[ ]{2,}', ' ', _prepare_trim(x))
+
+
 String.register_prepare_function(_prepare_trim, name="trim")
+String.register_prepare_function(_prepare_normalize_whitespace, name="normalize_whitespace")

--- a/prestans3/types/string.py
+++ b/prestans3/types/string.py
@@ -70,3 +70,10 @@ def _min_max_string_check_config(type, config):
 
 
 String.register_config_check(_min_max_string_check_config, name="min_max_string_check_config")
+
+
+def _prepare_trim(x):
+    return x.strip()
+
+
+String.register_prepare_function(_prepare_trim, name="trim")

--- a/prestans3/utils.py
+++ b/prestans3/utils.py
@@ -125,6 +125,15 @@ class MergingProxyDictionary(dict):
         else:
             super(MergingProxyDictionary, self).__init__(initial_values)
 
+    def own_items(self):
+        return super(MergingProxyDictionary, self).items()
+
+    def own_keys(self):
+        return super(MergingProxyDictionary, self).keys()
+
+    def own_values(self):
+        return super(MergingProxyDictionary, self).values()
+
     def _append_others(self, item):
         if self._others:
             return self._others.append(item)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -418,3 +418,21 @@ def test_merging_dictionary_does_not_skip_items():
 def test_terminating_type_is_object_when_not_specified_for_lazy_one_way_graph():
     # noinspection PyProtectedMember
     assert utils.LazyOneWayGraph()._terminating_type is object
+
+
+def test_merging_dictionary_can_access_own_items():
+    dictionary = MergingProxyDictionary({'foo': 'bar'}, {'baz': 'spam'})
+    assert dictionary.own_items() == {'foo': 'bar'}.items()
+
+
+def test_merging_dictionary_can_access_own_keys():
+    dictionary = MergingProxyDictionary({'foo': 'bar'}, {'baz': 'spam'})
+    assert dictionary.own_keys() == {'foo': 'bar'}.keys()
+
+
+def test_merging_dictionary_can_access_own_values():
+    dictionary = MergingProxyDictionary({'foo': 'bar'}, {'baz': 'spam'})
+    values = dictionary.own_values()
+    assert len(values) == 1
+    assert list(values)[0] == list({'foo': 'bar'}.values())[0]
+

--- a/tests/types/test_model.py
+++ b/tests/types/test_model.py
@@ -353,3 +353,12 @@ def test_get_prestans_attribute_property_raises_key_error_on_normal_attribute_ke
         _Model.get_prestans_attribute_property('spam')
     assert "'{}' is a normal python class attribute, not a {} instance".format('spam', _Property.__name__) in str(
         error.value)
+
+
+def test_property_with_prepare_stores_prepared_argument():
+    class _Model(Model):
+        foo = String.property(prepare=lambda x: 'bar')
+
+    model = _Model.mutable()
+    model.foo = 'not bar'
+    assert model.foo == 'bar'

--- a/tests/types/test_string.py
+++ b/tests/types/test_string.py
@@ -12,6 +12,7 @@ import pytest
 from prestans3.errors import ValidationException, PropertyConfigError
 from prestans3.types import Model
 from prestans3.types import String
+from prestans3.types.string import _prepare_trim
 
 
 def test_can_create_string():
@@ -102,3 +103,22 @@ def test_str_regex_property_rule_works():
     with pytest.raises(ValidationException) as exception:
         model.validate()
     assert '{} does not match the format_regex {}'.format('s1', r'[abc][123]')
+
+
+def test_prepare_trim_works():
+    assert _prepare_trim(' hello') == 'hello'
+    assert _prepare_trim(' hello ') == 'hello'
+    assert _prepare_trim('hello ') == 'hello'
+
+
+def test_prepare_trim_works_on_property():
+    class _M(Model):
+        my_string = String.property(prepare='trim')
+
+    model = _M.mutable()
+    model.my_string = ' hello'
+    assert model.my_string == 'hello'
+    model.my_string = 'hello '
+    assert model.my_string == 'hello'
+    model.my_string = '   hello        '
+    assert model.my_string == 'hello'

--- a/tests/types/test_string.py
+++ b/tests/types/test_string.py
@@ -12,7 +12,7 @@ import pytest
 from prestans3.errors import ValidationException, PropertyConfigError
 from prestans3.types import Model
 from prestans3.types import String
-from prestans3.types.string import _prepare_trim
+from prestans3.types.string import _prepare_trim, _prepare_normalize_whitespace
 
 
 def test_can_create_string():
@@ -122,3 +122,16 @@ def test_prepare_trim_works_on_property():
     assert model.my_string == 'hello'
     model.my_string = '   hello        '
     assert model.my_string == 'hello'
+
+
+def test_remove_whitespace():
+    assert _prepare_normalize_whitespace('my        name is    bob   ') == 'my name is bob'
+
+
+def test_remove_whitespace_works_on_property():
+    class _M(Model):
+        my_string = String.property(prepare='normalize_whitespace')
+
+    model = _M.mutable()
+    model.my_string = '   hello world      of white     space  removal         !  '
+    assert model.my_string == 'hello world of white space removal !'

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -84,3 +84,13 @@ def test_register_config_has_default_config():
 
     __Model.register_config_check(_test)
     assert __Model.config_checks['_test'] is _test
+
+
+def test_property_may_accept_prepare_argument():
+    class _Model(Model):
+        prop = ImmutableType.property(prepare=lambda x: None)
+
+
+# def test_prepare_argument_will_accept_predefined_function_name():
+#     class _Model(Model):
+#         prop = ImmutableType.property(prepare='some_func')

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -14,6 +14,7 @@ from prestans3.errors import ValidationException
 from prestans3.types import Integer
 from prestans3.types import Model
 from prestans3.types import String, _Property, ImmutableType
+from prestans3.utils import MergingProxyDictionary
 
 
 class MyClass(Model):
@@ -91,15 +92,21 @@ def test_property_may_accept_prepare_argument():
         prop = ImmutableType.property(prepare=lambda x: None)
 
 
-def test_type_may_register_relevant_prepare_function():
-    class _IM(ImmutableType):
-        pass
+# def test_type_can_access_graph_storage_for_own_prepare_functions():
+#     class _IM(ImmutableType):
+#         pass
+#
+#     assert isinstance(_IM.prepare_functions, MergingProxyDictionary)
+#     assert len(_IM.own_values) == 0
 
-    _IM.register_prepare_function(lambda x: None)
 
-    class _Model(Model):
-        im = _IM.property(prepare='some_new_prepare_func')
-
+# def test_type_may_register_relevant_prepare_function():
+#     class _IM(ImmutableType):
+#         pass
+#
+#     noop = lambda x: None
+#     _IM.register_prepare_function(noop, name="noop")
+#     _IM.prepare_functions['noop'] == noop
 
 # def test_prepare_argument_will_accept_predefined_function_name():
 #     class _Model(Model):

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -197,21 +197,20 @@ def test_can_provide_list_of_prepare_functions_resolved_in_order():
         pass
 
     _IM.register_prepare_function(lambda x: x * x, name="square")
+
     def _divide_by_2(x):
         return x / 2
 
     prop = _IM.property(prepare=['square', lambda x: x + 2, _divide_by_2])
-    prop.prepare_process_function(2) == 3
+    assert prop.prepare_process_function(2) == 3
+    prop = _IM.property(prepare=[lambda x: x + 2, 'square', _divide_by_2])
+    assert prop.prepare_process_function(2) == 8
 
 
-# def test_prepare_argument_will_accept_predefined_function_name():
-#     class _IM(ImmutableType):
-#         pass
-#
-#     noop = lambda x: None
-#     _IM.register_prepare_function(noop, name="something")
-#
-#     class _M(Model):
-#         prop = ImmutableType.property(prepare='something')
-#
-#     assert _M.prepare_functions['something']
+def test_resolve_prepare_function_raises_type_error_on_invalid_argument():
+    with pytest.raises(TypeError) as error:
+        _Property(ImmutableType)._resolve_prepare_function(1)
+    assert "prepare argument to property must be a str name of a pre-registered prepare function, a" + \
+           "custom one-argument function or a list of any of the previous values, received: {} of type {}".format(
+               1, int.__name__
+           ) in str(error.value)

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -112,7 +112,7 @@ def test_type_may_register_relevant_prepare_function():
 def test_resolve_prepare_function_on_property_will_return_func_if_function_provided():
     prop = _Property(ImmutableType)
     noop = lambda x: None
-    assert prop._resolve_preapre_function(noop) == noop
+    assert prop._resolve_prepare_function(noop) == noop
 
 
 def test_resolve_prepare_function_raises_type_error_when_passed_function_with_less_or_more_than_one_argument():
@@ -125,18 +125,18 @@ def test_resolve_prepare_function_raises_type_error_when_passed_function_with_le
     def _one_arg(x): None
 
     with pytest.raises(TypeError) as error:
-        prop._resolve_preapre_function(_no_args)
+        prop._resolve_prepare_function(_no_args)
     assert 'provided prepare function should only 1 argument, received function has {}: {}({})'.format(
         0, _no_args.__name__, ''
     )
 
     with pytest.raises(TypeError) as error:
-        prop._resolve_preapre_function(_two_args)
+        prop._resolve_prepare_function(_two_args)
     assert 'provided prepare function should only 1 argument, received function has {}: {}({})'.format(
         2, _two_args.__name__, ", ".join(_two_args.__code__.co_varnames)
     )
 
-    assert prop._resolve_preapre_function(_one_arg) == _one_arg
+    assert prop._resolve_prepare_function(_one_arg) == _one_arg
 
 
 def test_string_parameter_raises_key_error_on_no_pre_registered_prepare_function_with_name():
@@ -147,9 +147,9 @@ def test_string_parameter_raises_key_error_on_no_pre_registered_prepare_function
     _IM.register_prepare_function(noop, name='here')
     prop = _IM.property()
 
-    assert prop._resolve_preapre_function('here') == noop
+    assert prop._resolve_prepare_function('here') == noop
     with pytest.raises(KeyError) as error:
-        prop._resolve_preapre_function('not here')
+        prop._resolve_prepare_function('not here')
     assert "'{}' is not a registered prepare function of {}".format('not here', _IM.__name__) in str(error.value)
 
 # def test_get_prepare_process_method_on_property_returns_function_that_adjusts_input_as_expected():

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -152,18 +152,23 @@ def test_string_parameter_raises_key_error_on_no_pre_registered_prepare_function
         prop._resolve_prepare_function('not here')
     assert "'{}' is not a registered prepare function of {}".format('not here', _IM.__name__) in str(error.value)
 
-# def test_get_prepare_process_method_on_property_returns_function_that_adjusts_input_as_expected():
-#     class _IM(ImmutableType):
-#         pass
+
+def test_get_prepare_process_method_on_property_returns_function_that_adjusts_input_as_expected():
+    class _IM(ImmutableType):
+        pass
+
+    double = lambda x: x + x
+    _IM.register_prepare_function(double, name="double")
+
+    prop = ImmutableType.property(prepare=double)
+    function = prop.prepare_process_function
+    assert function.__code__.co_argcount == 1
+    assert function(1) == 2
+    assert function("foo") == "foofoo"
+
 #
-#     double = lambda x: x + x
-#     _IM.register_prepare_function(double, name="double")
-#
-#     prop = ImmutableType.property(prepare=double)
-#     function = prop.get_prepare_input_function()
-#     assert function.__code__.co_argcount == 1
-#     assert function(1) == 2
-#     assert function("foo") == "foofoo"
+# def test_get_prepare_process_method_accepts_named_parameter_correctly():
+#     class _IM
 
 # def test_prepare_argument_will_accept_predefined_function_name():
 #     class _IM(ImmutableType):

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -214,3 +214,7 @@ def test_resolve_prepare_function_raises_type_error_on_invalid_argument():
            "custom one-argument function or a list of any of the previous values, received: {} of type {}".format(
                1, int.__name__
            ) in str(error.value)
+
+
+def test_no_prepare_argument_does_not_break_code():
+    _Property(ImmutableType).prepare_process_function(1)

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -166,9 +166,18 @@ def test_get_prepare_process_method_on_property_returns_function_that_adjusts_in
     assert function(1) == 2
     assert function("foo") == "foofoo"
 
-#
-# def test_get_prepare_process_method_accepts_named_parameter_correctly():
-#     class _IM
+
+def test_get_prepare_process_method_accepts_named_parameter_correctly():
+    class _IM(ImmutableType):
+        pass
+
+    double = lambda x: x + x
+    _IM.register_prepare_function(double, name="double")
+
+    prop = _IM.property(prepare="double")
+    function = prop.prepare_process_function
+    assert function(1) == 2
+    assert function("foo") == "foofoo"
 
 # def test_prepare_argument_will_accept_predefined_function_name():
 #     class _IM(ImmutableType):

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -92,22 +92,23 @@ def test_property_may_accept_prepare_argument():
         prop = ImmutableType.property(prepare=lambda x: None)
 
 
-# def test_type_can_access_graph_storage_for_own_prepare_functions():
-#     class _IM(ImmutableType):
-#         pass
-#
-#     assert isinstance(_IM.prepare_functions, MergingProxyDictionary)
-#     assert len(_IM.own_values) == 0
+def test_type_can_access_graph_storage_for_own_prepare_functions():
+    class _IM(ImmutableType):
+        pass
+
+    assert isinstance(_IM.prepare_functions, MergingProxyDictionary)
+    assert len(_IM.prepare_functions.own_items()) == 0
 
 
-# def test_type_may_register_relevant_prepare_function():
-#     class _IM(ImmutableType):
-#         pass
-#
-#     noop = lambda x: None
-#     _IM.register_prepare_function(noop, name="noop")
-#     _IM.prepare_functions['noop'] == noop
 
-# def test_prepare_argument_will_accept_predefined_function_name():
-#     class _Model(Model):
-#         prop = ImmutableType.property(prepare='some_func')
+    # def test_type_may_register_relevant_prepare_function():
+    #     class _IM(ImmutableType):
+    #         pass
+    #
+    #     noop = lambda x: None
+    #     _IM.register_prepare_function(noop, name="noop")
+    #     _IM.prepare_functions['noop'] == noop
+
+    # def test_prepare_argument_will_accept_predefined_function_name():
+    #     class _Model(Model):
+    #         prop = ImmutableType.property(prepare='some_func')

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -179,6 +179,31 @@ def test_get_prepare_process_method_accepts_named_parameter_correctly():
     assert function(1) == 2
     assert function("foo") == "foofoo"
 
+
+def test_can_provide_custom_function():
+    class _IM(ImmutableType):
+        pass
+
+    double = lambda x: x + x
+    prop_1 = ImmutableType.property(prepare=double)
+    prop_2 = ImmutableType.property(prepare=lambda x: x - x)
+
+    assert prop_1.prepare_process_function(1) == 2
+    assert prop_2.prepare_process_function(1) == 0
+
+
+def test_can_provide_list_of_prepare_functions_resolved_in_order():
+    class _IM(ImmutableType):
+        pass
+
+    _IM.register_prepare_function(lambda x: x * x, name="square")
+    def _divide_by_2(x):
+        return x / 2
+
+    prop = _IM.property(prepare=['square', lambda x: x + 2, _divide_by_2])
+    prop.prepare_process_function(2) == 3
+
+
 # def test_prepare_argument_will_accept_predefined_function_name():
 #     class _IM(ImmutableType):
 #         pass

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -91,6 +91,16 @@ def test_property_may_accept_prepare_argument():
         prop = ImmutableType.property(prepare=lambda x: None)
 
 
+def test_type_may_register_relevant_prepare_function():
+    class _IM(ImmutableType):
+        pass
+
+    _IM.register_prepare_function(lambda x: None)
+
+    class _Model(Model):
+        im = _IM.property(prepare='some_new_prepare_func')
+
+
 # def test_prepare_argument_will_accept_predefined_function_name():
 #     class _Model(Model):
 #         prop = ImmutableType.property(prepare='some_func')

--- a/tests/types/test_type.py
+++ b/tests/types/test_type.py
@@ -148,6 +148,9 @@ def test_string_parameter_raises_key_error_on_no_pre_registered_prepare_function
     prop = _IM.property()
 
     assert prop._resolve_preapre_function('here') == noop
+    with pytest.raises(KeyError) as error:
+        prop._resolve_preapre_function('not here')
+    assert "'{}' is not a registered prepare function of {}".format('not here', _IM.__name__) in str(error.value)
 
 # def test_get_prepare_process_method_on_property_returns_function_that_adjusts_input_as_expected():
 #     class _IM(ImmutableType):


### PR DESCRIPTION
resolves #15.

property rule may accept a `prepare` argument that will run pre-defined or custom data manipulation functions before validated.

example:

```python
def double(x):
    return x + x

class _MyModel(Model):
    my_string = String.property(prepare=['trim', double, lambda x: x + ' blacksheep'])

model = _MyModel.mutable()
model.my_string = '  bar  '
assert model.my_string == 'barbar blacksheep'
```